### PR TITLE
Support non-Windows environments

### DIFF
--- a/Discord-Bot/Bot.py
+++ b/Discord-Bot/Bot.py
@@ -15,23 +15,22 @@ from TAC_API import *
 
 #functions
 def loadFiles(files):
-    dir=os.path.dirname(os.path.realpath(__file__))+'\\res'
-    ret=[]
+    dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'res')
+    ret = []
     for file in files:
-        path = dir+'\\' + file
+        path = os.path.join(dir, file)
         if not os.path.exists(path):
             print(path, " was not found.")
             continue
-        
-        print (file)
+        print(file)
+
         try:
-            with open(path, "rt",encoding='utf8') as f:
-                ret.append(json.loads(f.read()))  
+            with open(path, "rt", encoding='utf8') as f:
+                ret.append(json.loads(f.read()))
         except ValueError:
-            with open(path, "rt",encoding='utf-8-sig') as f:
-                ret.append(json.loads(f.read())) 
-            
-    
+            with open(path, "rt", encoding='utf-8-sig') as f:
+                ret.append(json.loads(f.read()))
+
     return ret
 
 def elementColor(element):
@@ -92,7 +91,6 @@ def timeDif_hms(time):
 #global vars
 prefix='o?'
 bot = commands.Bot(command_prefix=prefix)
-dir=os.path.dirname(os.path.realpath(__file__))+'\\res'
 [units,drops,gears,jobs]=loadFiles(['units.json','drops.json','gear.json','jobs.json'])
 
     


### PR DESCRIPTION
## What does this PR do?

This PR fixes the file path so that this code can be run on non-Windows OS.

## Why is this change being made?

Windows uses `\` as the delimiter for the directory structure: `C:\path\to\my\file`. Unix uses `/`: `/path/to/my/file`. `os.path.join()` allows the code to adapt according to the OS that it is running.

## How was this tested? How can the reviewer verify your testing?

```bash
$ python python Discord-Bot/Bot.py
units.json
drops.json
gear.json
jobs.json
Logged in as
alchemist-bot
431724312215683082
[<Guild id=427697976345886721 name='Testing Ground' chunked=True>]
------
^C%
```

## What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/4MwP0n2iPbkcM/giphy.gif)