### PR TITLE
Abstract out Discord token into env var

### DIFF
--- a/Discord-Bot/Bot.py
+++ b/Discord-Bot/Bot.py
@@ -387,5 +387,5 @@ async def debug(ctx):
     await ctx.send(embed=embed) 
 
 
-
-bot.run('NDM3ODY4OTQ4MTMwNzU4NjY4.DdYvnw.UTWQMqytfyiu6YXzkY4iIw4CqJY')
+BOT_TOKEN = os.environ.get('DISCORD_BOT_TOKEN')
+bot.run(BOT_TOKEN)


### PR DESCRIPTION
## What does this PR do?

This PR removes the hard-coded Discord token out of the source code and replace it with an environment variable.

## Why is this change being made?

Having the token hard-coded inside of the source code is considered sub-optimal for following reasons:
1. It is very easy to make a mistake and start running your un-tested code as the real Ouroboros.
1. In order to develop Ouroboros and test your working code, you have to have an uncommitted change. This makes `git`'s change notification useless for that file.
1. It is very easy to mistakenly commit your testing bot token and break the real Ouroboros.
1. The token is freely available, meaning anyone can read the source code and use the token. (i.e. I can easily deploy a malicious server using that token.)

## How was this tested? How can the reviewer verify your testing?

```bash
$ export DISCORD_BOT_TOKEN=SomeAwesomeToken
$ python Discord-Bot/Bot.py
units.json
drops.json
gear.json
jobs.json
Logged in as
alchemist-bot
431724312215683082
[<Guild id=427697976345886721 name='Testing Ground' chunked=True>]
------
o?unit
	 Suzuka
Jaro-Winkler 	Suzuka | 0.9523809523809524
^C%
```

## What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/exFVc8F5b4ZfW/giphy.gif)